### PR TITLE
Fix ESLint config in client

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -26,9 +26,6 @@
     "storybook": "start-storybook -p 9009 -s public",
     "build-storybook": "build-storybook -s public"
   },
-  "eslintConfig": {
-    "extends": "react-app"
-  },
   "browserslist": {
     "production": [
       ">0.2%",

--- a/client/src/stories/0-Welcome.stories.js
+++ b/client/src/stories/0-Welcome.stories.js
@@ -1,6 +1,4 @@
 import React from 'react';
-import { linkTo } from '@storybook/addon-links';
-import { Welcome } from '@storybook/react/demo';
 
 export default {
   title: 'Welcome'


### PR DESCRIPTION
.eslintrc was overridden in client folder by
`"eslintConfig": {
  "extends": "react-app"
},`
in client/package.json

I had to remove that config and fix a small issue with unused imports that could now be found by ESLint.